### PR TITLE
Making old content Q/A file obsolete

### DIFF
--- a/Request-Reviews/request-content-qa.md
+++ b/Request-Reviews/request-content-qa.md
@@ -1,14 +1,9 @@
-# Content Strategy and Writing
+# This document is now obsolete. 
+### The current content review process document is located here: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Practice%20Areas/Content/content-review-process.md
 
-* **This document applies only to External Contractors.**
 
-* **Definitions for terms used in this folder:**
 
-  * *"DSVA" refers to DSVA team members and DSVA detailees.*
-
-  * *"Internal contractors" refers to DSVA's primary vendor contractor and its subcontractors.*
-
-  * *"External contractors" refers to any other contractor team working on the Veteran-facing Services Platform.*
+~~## Content Strategy and Writing~~
 
 <hr>
 

--- a/Request-Reviews/request-content-qa.md
+++ b/Request-Reviews/request-content-qa.md
@@ -1,5 +1,5 @@
 # This document is now obsolete. 
-### The current content review process document is located here: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Practice%20Areas/Content/content-review-process.md
+### Click here for the current [content review process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/Practice%20Areas/Content/content-review-process.md) document. 
 
 
 


### PR DESCRIPTION
We need to mark this file as obsolete and outdated, so contractors don't get confused about the current content review process: 
https://github.com/department-of-veterans-affairs/va.gov-vfs-teams/blob/master/Request-Reviews/request-content-qa.md